### PR TITLE
Update contributing_code.rst with note about build essentials

### DIFF
--- a/doc/source/contributing_code.rst
+++ b/doc/source/contributing_code.rst
@@ -262,7 +262,7 @@ Ensure that you have a working C/C++ compiler (e.g. gcc or clang). You will also
         python -m pip install -e .
 
 
-.. note:: If installing  fails due to compiler ensure that you have the installed the build essentials package. It can be installed with your OS/distro's package manager. 
+.. note:: If installing  fails due to compiler ensure that you have the installed the build-essentials package. It can be installed with your OS/distro's package manager. 
 
 At this point you should be able to import MDAnalysis from your locally built version. If you are running the development version, this is visible from the version number ending in :code:`-dev0`. For example:
 

--- a/doc/source/contributing_code.rst
+++ b/doc/source/contributing_code.rst
@@ -261,6 +261,9 @@ Ensure that you have a working C/C++ compiler (e.g. gcc or clang). You will also
         cd ../testsuite/
         python -m pip install -e .
 
+
+.. note:: If installing  fails due to compiler ensure that you have the installed the build essentials package. It can be installed with your OS/distro's package manager. 
+
 At this point you should be able to import MDAnalysis from your locally built version. If you are running the development version, this is visible from the version number ending in :code:`-dev0`. For example:
 
     .. code-block:: bash


### PR DESCRIPTION
The last few times I've tried setting up an MDAnalysis development environment on Linux I've had compiler errors when using pip to build the package due to not having build-essentials installed, I figured I'd make a quick edit so others have an easier time troubleshooting. 